### PR TITLE
Drop support for Node.js < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
+  - "6"
+  - "8"
 
 notifications:
   email: false

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
-var lookup = require('../');
-var program = require('commander');
+const lookup = require('../');
+const program = require('commander');
 
 program
   .version(require('../package.json').version)
@@ -12,8 +12,8 @@ program
   .option('-d, --directory [path]', 'location of all stylus files')
   .parse(process.argv);
 
-var filename = program.filename;
-var directory = program.directory;
-var dep = program.args[0];
+const filename = program.filename;
+const directory = program.directory;
+const dep = program.args[0];
 
 console.log(lookup(dep, filename, directory));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var fs = require('fs');
-var isRelativePath = require('is-relative-path');
 var debug = require('debug')('stylus-lookup');
 
 /**
@@ -23,7 +22,7 @@ module.exports = function(dep, filename, directory) {
   var ext = path.extname(dep) ? '' : path.extname(filename);
   var resolved;
 
-  if (isRelativePath(dep)) {
+  if (!path.isAbsolute(dep)) {
     resolved = path.resolve(filename, dep) + ext;
 
     debug('resolved relative dependency: ' + resolved);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-var path = require('path');
-var fs = require('fs');
-var debug = require('debug')('stylus-lookup');
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const debug = require('debug')('stylus-lookup');
 
 /**
  * Determines the resolved dependency path according to
@@ -12,15 +14,15 @@ var debug = require('debug')('stylus-lookup');
  * @return {String}
  */
 module.exports = function(dep, filename, directory) {
-  var fileDir = path.dirname(filename);
+  const fileDir = path.dirname(filename);
 
   debug('trying to resolve: ' + dep);
   debug('filename: ', filename);
   debug('directory: ', directory);
 
   // Use the file's extension if necessary
-  var ext = path.extname(dep) ? '' : path.extname(filename);
-  var resolved;
+  const ext = path.extname(dep) ? '' : path.extname(filename);
+  let resolved;
 
   if (!path.isAbsolute(dep)) {
     resolved = path.resolve(filename, dep) + ext;
@@ -34,7 +36,7 @@ module.exports = function(dep, filename, directory) {
     }
   }
 
-  var samedir = path.resolve(fileDir, dep) + ext;
+  const samedir = path.resolve(fileDir, dep) + ext;
   debug('resolving dep about the parent file\'s directory: ' + samedir);
 
   if (fs.existsSync(samedir)) {
@@ -44,7 +46,7 @@ module.exports = function(dep, filename, directory) {
   }
 
   // Check for dep/index.styl file
-  var indexFile = path.join(path.resolve(fileDir, dep), 'index.styl');
+  const indexFile = path.join(path.resolve(fileDir, dep), 'index.styl');
   debug('resolving dep as if it points to an index.styl file: ' + indexFile);
 
   if (fs.existsSync(indexFile)) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mock-fs": "^4.4.2"
   },
   "dependencies": {
-    "commander": "~2.8.1",
+    "commander": "^2.8.1",
     "debug": "^3.1.0",
     "is-relative-path": "~1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.2",
   "description": "Get the file associated with an imported/required Stylus partial",
   "main": "index.js",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-stylus-lookup",
   "devDependencies": {
-    "jscs": "~1.13.1",
-    "mocha": "~2.2.5",
-    "mock-fs": "~3.0.0"
+    "jscs": "^3.0.7",
+    "mocha": "^4.1.0",
+    "mock-fs": "^4.4.2"
   },
   "dependencies": {
     "commander": "~2.8.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "commander": "^2.8.1",
-    "debug": "^3.1.0",
-    "is-relative-path": "~1.0.0"
+    "debug": "^3.1.0"
   }
 }


### PR DESCRIPTION
Please double check the removal of `is-relative-path` the module behaves a little bit different than the native Node function.